### PR TITLE
Add floatLE doubleLE uInt32LE and int32LE read+write methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ https://nodejs.org/api/buffer.html#bufwriteuint32levalue-offset
 
 See https://nodejs.org/api/buffer.html#bufwriteint32levalue-offset
 
+### `b4a.readDoubleLE(buffer[, offset])`
+
+See https://nodejs.org/api/buffer.html#bufreaddoubleleoffset
+
+### `b4a.readFloatLE(buffer[, offset])`
+
+See https://nodejs.org/api/buffer.html#bufreadfloatleoffset
+
+### `b4a.readUInt32LE(buffer[, offset])`
+
+See https://nodejs.org/api/buffer.html#bufreaduint32leoffset
+
+### `b4a.readInt32LE(buffer[, offset])`
+
+See https://nodejs.org/api/buffer.html#bufreadint32leoffset
 ## License
 
 ISC

--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ See https://nodejs.org/api/buffer.html#buftostringencoding-start-end
 
 See https://nodejs.org/api/buffer.html#bufwritestring-offset-length-encoding
 
+#### `b4a.writeDoubleLE(buffer, value[, offset])`
+See https://nodejs.org/api/buffer.html#bufwritedoublelevalue-offset
+
+#### `b4a.writeFloatLE(buffer, value[, offset])`
+
+See https://nodejs.org/api/buffer.html#bufwritefloatlevalue-offset
+
+#### `b4a.writeUInt32LE(buffer, value[, offset])`
+
+https://nodejs.org/api/buffer.html#bufwriteuint32levalue-offset
+
+#### `b4a.writeInt32LE(buffer, value[, offset])`
+
+See https://nodejs.org/api/buffer.html#bufwriteint32levalue-offset
+
 ## License
 
 ISC

--- a/browser.js
+++ b/browser.js
@@ -395,6 +395,46 @@ function write (buffer, string, offset, length, encoding) {
   return codecFor(encoding).write(buffer, string, offset, length)
 }
 
+function writeDoubleLE (buffer, value, offset) {
+  offset ??= 0
+
+  const view = new DataView(buffer.buffer)
+  view.setFloat64(offset, value, true)
+
+  const bytesInDouble = 8
+  return offset + bytesInDouble
+}
+
+function writeFloatLE (buffer, value, offset) {
+  offset ??= 0
+
+  const view = new DataView(buffer.buffer)
+  view.setFloat32(offset, value, true)
+
+  const bytesInFloat = 4
+  return offset + bytesInFloat
+}
+
+function writeUInt32LE (buffer, value, offset) {
+  offset ??= 0
+
+  const view = new DataView(buffer.buffer)
+  view.setUint32(offset, value, true)
+
+  const bytesInUInt = 4
+  return offset + bytesInUInt
+}
+
+function writeInt32LE (buffer, value, offset) {
+  offset ??= 0
+
+  const view = new DataView(buffer.buffer)
+  view.setInt32(offset, value, true)
+
+  const bytesInInt = 4
+  return offset + bytesInInt
+}
+
 module.exports = {
   isBuffer,
   isEncoding,
@@ -416,5 +456,9 @@ module.exports = {
   swap64,
   toBuffer,
   toString,
-  write
+  write,
+  writeDoubleLE,
+  writeFloatLE,
+  writeUInt32LE,
+  writeInt32LE
 }

--- a/browser.js
+++ b/browser.js
@@ -435,6 +435,31 @@ function writeInt32LE (buffer, value, offset) {
   return offset + bytesInInt
 }
 
+function readDoubleLE (buffer, offset) {
+  const view = getDataview(buffer, offset)
+  return view.getFloat64(0, true)
+}
+
+function readFloatLE (buffer, offset) {
+  const view = getDataview(buffer, offset)
+  return view.getFloat32(0, true)
+}
+
+function readUInt32LE (buffer, offset) {
+  const view = getDataview(buffer, offset)
+  return view.getUint32(0, true)
+}
+
+function readInt32LE (buffer, offset) {
+  const view = getDataview(buffer, offset)
+  return view.getInt32(0, true)
+}
+
+function getDataview (buffer, offset) {
+  offset ??= 0
+  return new DataView(buffer.buffer, offset)
+}
+
 module.exports = {
   isBuffer,
   isEncoding,
@@ -460,5 +485,9 @@ module.exports = {
   writeDoubleLE,
   writeFloatLE,
   writeUInt32LE,
-  writeInt32LE
+  writeInt32LE,
+  readDoubleLE,
+  readFloatLE,
+  readUInt32LE,
+  readInt32LE
 }

--- a/browser.js
+++ b/browser.js
@@ -396,68 +396,71 @@ function write (buffer, string, offset, length, encoding) {
 }
 
 function writeDoubleLE (buffer, value, offset) {
-  offset ??= 0
+  if (offset === undefined) offset = 0
 
-  const view = new DataView(buffer.buffer)
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
   view.setFloat64(offset, value, true)
 
-  const bytesInDouble = 8
-  return offset + bytesInDouble
+  return offset + 8
 }
 
 function writeFloatLE (buffer, value, offset) {
-  offset ??= 0
+  if (offset === undefined) offset = 0
 
-  const view = new DataView(buffer.buffer)
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
   view.setFloat32(offset, value, true)
 
-  const bytesInFloat = 4
-  return offset + bytesInFloat
+  return offset + 4
 }
 
 function writeUInt32LE (buffer, value, offset) {
-  offset ??= 0
+  if (offset === undefined) offset = 0
 
-  const view = new DataView(buffer.buffer)
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
   view.setUint32(offset, value, true)
 
-  const bytesInUInt = 4
-  return offset + bytesInUInt
+  return offset + 4
 }
 
 function writeInt32LE (buffer, value, offset) {
-  offset ??= 0
+  if (offset === undefined) offset = 0
 
-  const view = new DataView(buffer.buffer)
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
   view.setInt32(offset, value, true)
 
-  const bytesInInt = 4
-  return offset + bytesInInt
+  return offset + 4
 }
 
 function readDoubleLE (buffer, offset) {
-  const view = getDataview(buffer, offset)
-  return view.getFloat64(0, true)
+  if (offset === undefined) offset = 0
+
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+
+  return view.getFloat64(offset, true)
 }
 
 function readFloatLE (buffer, offset) {
-  const view = getDataview(buffer, offset)
-  return view.getFloat32(0, true)
+  if (offset === undefined) offset = 0
+
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+
+  return view.getFloat32(offset, true)
 }
 
 function readUInt32LE (buffer, offset) {
-  const view = getDataview(buffer, offset)
-  return view.getUint32(0, true)
+  if (offset === undefined) offset = 0
+
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+
+  return view.getUint32(offset, true)
 }
 
 function readInt32LE (buffer, offset) {
-  const view = getDataview(buffer, offset)
-  return view.getInt32(0, true)
-}
+  if (offset === undefined) offset = 0
 
-function getDataview (buffer, offset) {
-  offset ??= 0
-  return new DataView(buffer.buffer, offset)
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+
+  return view.getInt32(offset, true)
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -99,6 +99,22 @@ function writeInt32LE (buffer, value, offset) {
   return toBuffer(buffer).writeInt32LE(value, offset)
 }
 
+function readDoubleLE (buffer, offset) {
+  return toBuffer(buffer).readDoubleLE(offset)
+}
+
+function readFloatLE (buffer, offset) {
+  return toBuffer(buffer).readFloatLE(offset)
+}
+
+function readUInt32LE (buffer, offset) {
+  return toBuffer(buffer).readUInt32LE(offset)
+}
+
+function readInt32LE (buffer, offset) {
+  return toBuffer(buffer).readInt32LE(offset)
+}
+
 module.exports = {
   isBuffer,
   isEncoding,
@@ -124,5 +140,9 @@ module.exports = {
   writeDoubleLE,
   writeFloatLE,
   writeUInt32LE,
-  writeInt32LE
+  writeInt32LE,
+  readDoubleLE,
+  readFloatLE,
+  readUInt32LE,
+  readInt32LE
 }

--- a/index.js
+++ b/index.js
@@ -83,6 +83,22 @@ function write (buffer, string, offset, length, encoding) {
   return toBuffer(buffer).write(string, offset, length, encoding)
 }
 
+function writeDoubleLE (buffer, value, offset) {
+  return toBuffer(buffer).writeDoubleLE(value, offset)
+}
+
+function writeFloatLE (buffer, value, offset) {
+  return toBuffer(buffer).writeFloatLE(value, offset)
+}
+
+function writeUInt32LE (buffer, value, offset) {
+  return toBuffer(buffer).writeUInt32LE(value, offset)
+}
+
+function writeInt32LE (buffer, value, offset) {
+  return toBuffer(buffer).writeInt32LE(value, offset)
+}
+
 module.exports = {
   isBuffer,
   isEncoding,
@@ -104,5 +120,9 @@ module.exports = {
   swap64,
   toBuffer,
   toString,
-  write
+  write,
+  writeDoubleLE,
+  writeFloatLE,
+  writeUInt32LE,
+  writeInt32LE
 }

--- a/test/browser.mjs
+++ b/test/browser.mjs
@@ -194,6 +194,15 @@ test('writeDoubleLE', (t) => {
     t.is(updatedOffset, 16)
     t.is(new DataView(buffer.buffer).getFloat64(8, true), 123.456)
   })
+
+  t.test('sub-buffer', (t) => {
+    const buffer = b.alloc(16)
+    const sub = buffer.subarray(4)
+
+    b.writeDoubleLE(sub, 123.456)
+
+    t.is(new DataView(buffer.buffer).getFloat64(4, true), 123.456)
+  })
 })
 
 test('writeFloatLE', (t) => {
@@ -211,6 +220,15 @@ test('writeFloatLE', (t) => {
 
     t.is(updatedOffset, 8)
     t.is(new DataView(buffer.buffer).getFloat32(4, true), 123.5)
+  })
+
+  t.test('sub-buffer', (t) => {
+    const buffer = b.alloc(8)
+    const sub = buffer.subarray(2)
+
+    b.writeFloatLE(sub, 123.5)
+
+    t.is(new DataView(buffer.buffer).getFloat32(2, true), 123.5)
   })
 })
 
@@ -230,6 +248,15 @@ test('writeUInt32LE', (t) => {
     t.is(updatedOffset, 8)
     t.is(new DataView(buffer.buffer).getUint32(4, true), 123)
   })
+
+  t.test('sub-buffer', (t) => {
+    const buffer = b.alloc(8)
+    const sub = buffer.subarray(2)
+
+    b.writeUInt32LE(sub, 123)
+
+    t.is(new DataView(buffer.buffer).getUint32(2, true), 123)
+  })
 })
 
 test('writeInt32LE', (t) => {
@@ -248,14 +275,24 @@ test('writeInt32LE', (t) => {
     t.is(updatedOffset, 8)
     t.is(new DataView(buffer.buffer).getInt32(4, true), 123)
   })
+
+  t.test('sub-buffer', (t) => {
+    const buffer = b.alloc(8)
+    const sub = buffer.subarray(2)
+
+    b.writeInt32LE(sub, 123)
+
+    t.is(new DataView(buffer.buffer).getInt32(2, true), 123)
+  })
 })
 
 test('readDoubleLE', (t) => {
+  const expected = 5.447603722011605e-270
+
   t.test('offset 0', (t) => {
     const buffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
 
     const actual = b.readDoubleLE(buffer)
-    const expected = 5.447603722011605e-270
     t.is(actual, expected)
   })
 
@@ -265,17 +302,27 @@ test('readDoubleLE', (t) => {
     )
 
     const actual = b.readDoubleLE(buffer, 8)
-    const expected = 5.447603722011605e-270
+    t.is(actual, expected)
+  })
+
+  t.test('sub-buffer', (t) => {
+    const buffer = new Uint8Array(
+      [...new Array(4).fill(0), ...[1, 2, 3, 4, 5, 6, 7, 8]]
+    )
+    const sub = buffer.subarray(4)
+
+    const actual = b.readDoubleLE(sub)
     t.is(actual, expected)
   })
 })
 
 test('readFloatLE', (t) => {
+  const expected = 1.539989614439558e-36
+
   t.test('offset 0', (t) => {
     const buffer = new Uint8Array([1, 2, 3, 4])
 
     const actual = b.readFloatLE(buffer)
-    const expected = 1.539989614439558e-36
     t.is(actual, expected)
   })
 
@@ -283,17 +330,25 @@ test('readFloatLE', (t) => {
     const buffer = new Uint8Array([0, 0, 0, 0, 1, 2, 3, 4])
 
     const actual = b.readFloatLE(buffer, 4)
-    const expected = 1.539989614439558e-36
+    t.is(actual, expected)
+  })
+
+  t.test('sub-buffer', (t) => {
+    const buffer = new Uint8Array([0, 0, 1, 2, 3, 4])
+    const sub = buffer.subarray(2)
+
+    const actual = b.readFloatLE(sub)
     t.is(actual, expected)
   })
 })
 
 test('readUInt32LE', (t) => {
+  const expected = '78563412'
+
   t.test('Offset 0', (t) => {
     const buffer = new Uint8Array([0x12, 0x34, 0x56, 0x78])
 
     const actual = b.readUInt32LE(buffer).toString(16)
-    const expected = '78563412'
     t.is(actual, expected)
   })
 
@@ -301,17 +356,25 @@ test('readUInt32LE', (t) => {
     const buffer = new Uint8Array([0, 0, 0, 0, 0x12, 0x34, 0x56, 0x78])
 
     const actual = b.readUInt32LE(buffer, 4).toString(16)
-    const expected = '78563412'
+    t.is(actual, expected)
+  })
+
+  t.test('sub-buffer', (t) => {
+    const buffer = new Uint8Array([0, 0, 0x12, 0x34, 0x56, 0x78])
+    const sub = buffer.subarray(2)
+
+    const actual = b.readUInt32LE(sub).toString(16)
     t.is(actual, expected)
   })
 })
 
 test('readInt32LE', (t) => {
+  const expected = 83886080
+
   t.test('Offset 0', (t) => {
     const buffer = new Uint8Array([0, 0, 0, 5])
 
     const actual = b.readInt32LE(buffer)
-    const expected = 83886080
     t.is(actual, expected)
   })
 
@@ -319,7 +382,14 @@ test('readInt32LE', (t) => {
     const buffer = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 5])
 
     const actual = b.readInt32LE(buffer, 4)
-    const expected = 83886080
+    t.is(actual, expected)
+  })
+
+  t.test('sub-buffer', (t) => {
+    const buffer = new Uint8Array([0, 0, 0, 0, 0, 5])
+    const sub = buffer.subarray(2)
+
+    const actual = b.readInt32LE(sub)
     t.is(actual, expected)
   })
 })

--- a/test/browser.mjs
+++ b/test/browser.mjs
@@ -249,3 +249,77 @@ test('writeInt32LE', (t) => {
     t.is(new DataView(buffer.buffer).getInt32(4, true), 123)
   })
 })
+
+test('readDoubleLE', (t) => {
+  t.test('offset 0', (t) => {
+    const buffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+
+    const actual = b.readDoubleLE(buffer)
+    const expected = 5.447603722011605e-270
+    t.is(actual, expected)
+  })
+
+  t.test('other offset', (t) => {
+    const buffer = new Uint8Array(
+      [...new Array(8).fill(0), ...[1, 2, 3, 4, 5, 6, 7, 8]]
+    )
+
+    const actual = b.readDoubleLE(buffer, 8)
+    const expected = 5.447603722011605e-270
+    t.is(actual, expected)
+  })
+})
+
+test('readFloatLE', (t) => {
+  t.test('offset 0', (t) => {
+    const buffer = new Uint8Array([1, 2, 3, 4])
+
+    const actual = b.readFloatLE(buffer)
+    const expected = 1.539989614439558e-36
+    t.is(actual, expected)
+  })
+
+  t.test('other offset', (t) => {
+    const buffer = new Uint8Array([0, 0, 0, 0, 1, 2, 3, 4])
+
+    const actual = b.readFloatLE(buffer, 4)
+    const expected = 1.539989614439558e-36
+    t.is(actual, expected)
+  })
+})
+
+test('readUInt32LE', (t) => {
+  t.test('Offset 0', (t) => {
+    const buffer = new Uint8Array([0x12, 0x34, 0x56, 0x78])
+
+    const actual = b.readUInt32LE(buffer).toString(16)
+    const expected = '78563412'
+    t.is(actual, expected)
+  })
+
+  t.test('other offset', (t) => {
+    const buffer = new Uint8Array([0, 0, 0, 0, 0x12, 0x34, 0x56, 0x78])
+
+    const actual = b.readUInt32LE(buffer, 4).toString(16)
+    const expected = '78563412'
+    t.is(actual, expected)
+  })
+})
+
+test('readInt32LE', (t) => {
+  t.test('Offset 0', (t) => {
+    const buffer = new Uint8Array([0, 0, 0, 5])
+
+    const actual = b.readInt32LE(buffer)
+    const expected = 83886080
+    t.is(actual, expected)
+  })
+
+  t.test('other offset', (t) => {
+    const buffer = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 5])
+
+    const actual = b.readInt32LE(buffer, 4)
+    const expected = 83886080
+    t.is(actual, expected)
+  })
+})

--- a/test/browser.mjs
+++ b/test/browser.mjs
@@ -177,3 +177,75 @@ test('toString', (t) => {
     t.is(b.toString(buffer, 'utf16le'), '\u0201\u0403')
   })
 })
+
+test('writeDoubleLE', (t) => {
+  t.test('offset 0', (t) => {
+    const buffer = b.alloc(8)
+    const updatedOffset = b.writeDoubleLE(buffer, 123.456)
+
+    t.is(updatedOffset, 8)
+    t.is(new DataView(buffer.buffer).getFloat64(0, true), 123.456)
+  })
+
+  t.test('other offset', (t) => {
+    const buffer = b.alloc(16)
+    const updatedOffset = b.writeDoubleLE(buffer, 123.456, 8)
+
+    t.is(updatedOffset, 16)
+    t.is(new DataView(buffer.buffer).getFloat64(8, true), 123.456)
+  })
+})
+
+test('writeFloatLE', (t) => {
+  t.test('offset 0', (t) => {
+    const buffer = b.alloc(4)
+    const updatedOffset = b.writeFloatLE(buffer, 123.5)
+
+    t.is(updatedOffset, 4)
+    t.is(new DataView(buffer.buffer).getFloat32(0, true), 123.5)
+  })
+
+  t.test('other offset', (t) => {
+    const buffer = b.alloc(8)
+    const updatedOffset = b.writeFloatLE(buffer, 123.5, 4)
+
+    t.is(updatedOffset, 8)
+    t.is(new DataView(buffer.buffer).getFloat32(4, true), 123.5)
+  })
+})
+
+test('writeUInt32LE', (t) => {
+  t.test('offset 0', (t) => {
+    const buffer = b.alloc(4)
+    const updatedOffset = b.writeUInt32LE(buffer, 123)
+
+    t.is(updatedOffset, 4)
+    t.is(new DataView(buffer.buffer).getUint32(0, true), 123)
+  })
+
+  t.test('other offset', (t) => {
+    const buffer = b.alloc(8)
+    const updatedOffset = b.writeUInt32LE(buffer, 123, 4)
+
+    t.is(updatedOffset, 8)
+    t.is(new DataView(buffer.buffer).getUint32(4, true), 123)
+  })
+})
+
+test('writeInt32LE', (t) => {
+  t.test('offset 0', (t) => {
+    const buffer = b.alloc(4)
+    const updatedOffset = b.writeInt32LE(buffer, 123)
+
+    t.is(updatedOffset, 4)
+    t.is(new DataView(buffer.buffer).getInt32(0, true), 123)
+  })
+
+  t.test('other offset', (t) => {
+    const buffer = b.alloc(8)
+    const updatedOffset = b.writeInt32LE(buffer, 123, 4)
+
+    t.is(updatedOffset, 8)
+    t.is(new DataView(buffer.buffer).getInt32(4, true), 123)
+  })
+})

--- a/test/node.mjs
+++ b/test/node.mjs
@@ -1,4 +1,5 @@
 import test from 'brittle'
+
 import b from '../index.js'
 
 test('writeDoubleLE', (t) => {
@@ -67,4 +68,76 @@ test('writeInt32LE', (t) => {
   const arrayOffset = b.writeInt32LE(array, value, 0)
   t.is(arrayOffset, 4)
   t.alike(Buffer.from(array), expectedBuffer)
+})
+
+test('readDoubleLE', (t) => {
+  t.test('from buffer', (t) => {
+    const buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8])
+
+    const actual = b.readDoubleLE(buffer)
+    const expected = 5.447603722011605e-270
+    t.is(actual, expected)
+  })
+
+  t.test('from uint8Array', (t) => {
+    const buffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+
+    const actual = b.readDoubleLE(buffer)
+    const expected = 5.447603722011605e-270
+    t.is(actual, expected)
+  })
+})
+
+test('readFloatLE', (t) => {
+  t.test('from buffer', (t) => {
+    const buffer = Buffer.from([1, 2, 3, 4])
+
+    const actual = b.readFloatLE(buffer)
+    const expected = 1.539989614439558e-36
+    t.is(actual, expected)
+  })
+
+  t.test('from uint8Array', (t) => {
+    const buffer = new Uint8Array([1, 2, 3, 4])
+
+    const actual = b.readFloatLE(buffer)
+    const expected = 1.539989614439558e-36
+    t.is(actual, expected)
+  })
+})
+
+test('readUInt32LE', (t) => {
+  t.test('from buffer', (t) => {
+    const buffer = Buffer.from([0x12, 0x34, 0x56, 0x78])
+
+    const actual = b.readUInt32LE(buffer).toString(16)
+    const expected = '78563412'
+    t.is(actual, expected)
+  })
+
+  t.test('from uint8Array', (t) => {
+    const buffer = new Uint8Array([0x12, 0x34, 0x56, 0x78])
+
+    const actual = b.readUInt32LE(buffer).toString(16)
+    const expected = '78563412'
+    t.is(actual, expected)
+  })
+})
+
+test('readInt32LE', (t) => {
+  t.test('from buffer', (t) => {
+    const buffer = Buffer.from([0, 0, 0, 5])
+
+    const actual = b.readInt32LE(buffer)
+    const expected = 83886080
+    t.is(actual, expected)
+  })
+
+  t.test('from uint8Array', (t) => {
+    const buffer = new Uint8Array([0, 0, 0, 5])
+
+    const actual = b.readInt32LE(buffer)
+    const expected = 83886080
+    t.is(actual, expected)
+  })
 })

--- a/test/node.mjs
+++ b/test/node.mjs
@@ -9,15 +9,19 @@ test('writeDoubleLE', (t) => {
   const expectedBuffer = Buffer.alloc(8)
   expectedBuffer.writeDoubleLE(value, 0)
 
-  const buffer = Buffer.alloc(8)
-  const bufferOffset = b.writeDoubleLE(buffer, value, 0)
-  t.is(bufferOffset, 8)
-  t.alike(buffer, expectedBuffer)
+  t.test('from buffer', (t) => {
+    const buffer = Buffer.alloc(8)
+    const bufferOffset = b.writeDoubleLE(buffer, value, 0)
+    t.is(bufferOffset, 8)
+    t.alike(buffer, expectedBuffer)
+  })
 
-  const array = new Uint8Array(8)
-  const arrayOffset = b.writeDoubleLE(array, value, 0)
-  t.is(arrayOffset, 8)
-  t.alike(Buffer.from(array), expectedBuffer)
+  t.test('from array', (t) => {
+    const array = new Uint8Array(8)
+    const arrayOffset = b.writeDoubleLE(array, value, 0)
+    t.is(arrayOffset, 8)
+    t.alike(Buffer.from(array), expectedBuffer)
+  })
 })
 
 test('writeFloatLE', (t) => {
@@ -26,15 +30,19 @@ test('writeFloatLE', (t) => {
   const expectedBuffer = Buffer.alloc(4)
   expectedBuffer.writeFloatLE(value, 0)
 
-  const buffer = Buffer.alloc(4)
-  const bufferOffset = b.writeFloatLE(buffer, value, 0)
-  t.is(bufferOffset, 4)
-  t.alike(buffer, expectedBuffer)
+  t.test('from buffer', (t) => {
+    const buffer = Buffer.alloc(4)
+    const bufferOffset = b.writeFloatLE(buffer, value, 0)
+    t.is(bufferOffset, 4)
+    t.alike(buffer, expectedBuffer)
+  })
 
-  const array = new Uint8Array(4)
-  const arrayOffset = b.writeFloatLE(array, value, 0)
-  t.is(arrayOffset, 4)
-  t.alike(Buffer.from(array), expectedBuffer)
+  t.test('from array', (t) => {
+    const array = new Uint8Array(4)
+    const arrayOffset = b.writeFloatLE(array, value, 0)
+    t.is(arrayOffset, 4)
+    t.alike(Buffer.from(array), expectedBuffer)
+  })
 })
 
 test('writeUInt32LE', (t) => {
@@ -43,15 +51,19 @@ test('writeUInt32LE', (t) => {
   const expectedBuffer = Buffer.alloc(4)
   expectedBuffer.writeUInt32LE(value, 0)
 
-  const buffer = Buffer.alloc(4)
-  const bufferOffset = b.writeUInt32LE(buffer, value, 0)
-  t.is(bufferOffset, 4)
-  t.alike(buffer, expectedBuffer)
+  t.test('from buffer', (t) => {
+    const buffer = Buffer.alloc(4)
+    const bufferOffset = b.writeUInt32LE(buffer, value, 0)
+    t.is(bufferOffset, 4)
+    t.alike(buffer, expectedBuffer)
+  })
 
-  const array = new Uint8Array(4)
-  const arrayOffset = b.writeUInt32LE(array, value, 0)
-  t.is(arrayOffset, 4)
-  t.alike(Buffer.from(array), expectedBuffer)
+  t.test('from array', (t) => {
+    const array = new Uint8Array(4)
+    const arrayOffset = b.writeUInt32LE(array, value, 0)
+    t.is(arrayOffset, 4)
+    t.alike(Buffer.from(array), expectedBuffer)
+  })
 })
 
 test('writeInt32LE', (t) => {
@@ -60,15 +72,19 @@ test('writeInt32LE', (t) => {
   const expectedBuffer = Buffer.alloc(4)
   expectedBuffer.writeInt32LE(value, 0)
 
-  const buffer = Buffer.alloc(4)
-  const bufferOffset = b.writeInt32LE(buffer, value, 0)
-  t.is(bufferOffset, 4)
-  t.alike(buffer, expectedBuffer)
+  t.test('from buffer', (t) => {
+    const buffer = Buffer.alloc(4)
+    const bufferOffset = b.writeInt32LE(buffer, value, 0)
+    t.is(bufferOffset, 4)
+    t.alike(buffer, expectedBuffer)
+  })
 
-  const array = new Uint8Array(4)
-  const arrayOffset = b.writeInt32LE(array, value, 0)
-  t.is(arrayOffset, 4)
-  t.alike(Buffer.from(array), expectedBuffer)
+  t.test('from array', (t) => {
+    const array = new Uint8Array(4)
+    const arrayOffset = b.writeInt32LE(array, value, 0)
+    t.is(arrayOffset, 4)
+    t.alike(Buffer.from(array), expectedBuffer)
+  })
 })
 
 test('readDoubleLE', (t) => {

--- a/test/node.mjs
+++ b/test/node.mjs
@@ -1,6 +1,7 @@
 import test from 'brittle'
 
 import b from '../index.js'
+import browserExports from '../browser.js'
 
 test('writeDoubleLE', (t) => {
   const value = 123.456
@@ -140,4 +141,14 @@ test('readInt32LE', (t) => {
     const expected = 83886080
     t.is(actual, expected)
   })
+})
+
+test('browser.js and index.js export same functions', (t) => {
+  const browserFunctions = Object.keys(browserExports)
+  browserFunctions.sort()
+
+  const nodeFunctions = Object.keys(b)
+  nodeFunctions.sort()
+
+  t.alike(browserFunctions, nodeFunctions)
 })

--- a/test/node.mjs
+++ b/test/node.mjs
@@ -1,0 +1,70 @@
+import test from 'brittle'
+import b from '../index.js'
+
+test('writeDoubleLE', (t) => {
+  const value = 123.456
+
+  const expectedBuffer = Buffer.alloc(8)
+  expectedBuffer.writeDoubleLE(value, 0)
+
+  const buffer = Buffer.alloc(8)
+  const bufferOffset = b.writeDoubleLE(buffer, value, 0)
+  t.is(bufferOffset, 8)
+  t.alike(buffer, expectedBuffer)
+
+  const array = new Uint8Array(8)
+  const arrayOffset = b.writeDoubleLE(array, value, 0)
+  t.is(arrayOffset, 8)
+  t.alike(Buffer.from(array), expectedBuffer)
+})
+
+test('writeFloatLE', (t) => {
+  const value = 0xcafebabe
+
+  const expectedBuffer = Buffer.alloc(4)
+  expectedBuffer.writeFloatLE(value, 0)
+
+  const buffer = Buffer.alloc(4)
+  const bufferOffset = b.writeFloatLE(buffer, value, 0)
+  t.is(bufferOffset, 4)
+  t.alike(buffer, expectedBuffer)
+
+  const array = new Uint8Array(4)
+  const arrayOffset = b.writeFloatLE(array, value, 0)
+  t.is(arrayOffset, 4)
+  t.alike(Buffer.from(array), expectedBuffer)
+})
+
+test('writeUInt32LE', (t) => {
+  const value = 0xfeedface
+
+  const expectedBuffer = Buffer.alloc(4)
+  expectedBuffer.writeUInt32LE(value, 0)
+
+  const buffer = Buffer.alloc(4)
+  const bufferOffset = b.writeUInt32LE(buffer, value, 0)
+  t.is(bufferOffset, 4)
+  t.alike(buffer, expectedBuffer)
+
+  const array = new Uint8Array(4)
+  const arrayOffset = b.writeUInt32LE(array, value, 0)
+  t.is(arrayOffset, 4)
+  t.alike(Buffer.from(array), expectedBuffer)
+})
+
+test('writeInt32LE', (t) => {
+  const value = 0x05060708
+
+  const expectedBuffer = Buffer.alloc(4)
+  expectedBuffer.writeInt32LE(value, 0)
+
+  const buffer = Buffer.alloc(4)
+  const bufferOffset = b.writeInt32LE(buffer, value, 0)
+  t.is(bufferOffset, 4)
+  t.alike(buffer, expectedBuffer)
+
+  const array = new Uint8Array(4)
+  const arrayOffset = b.writeInt32LE(array, value, 0)
+  t.is(arrayOffset, 4)
+  t.alike(Buffer.from(array), expectedBuffer)
+})


### PR DESCRIPTION
# Add floatLE, doubleLE uInt32LE and int32LE read and write methods.

Please review with some care, as I don't have much experience with working directly with buffers. 

The pull-request is feature-complete, but marked as a draft because I'm not sure which style is preferred for the tests (I've never used brittle before). See for example test/node.mjs: writeDoubleLE defines multiple tests within the same block, whereas readDoubleLE uses subtests to do the same--which is preferred? 

Note: I also added a test to check that index.js and browser.js export the exact same functions. If this is not relevant, I'll remove it again.

 